### PR TITLE
Add invoice revision handling for repriced orders

### DIFF
--- a/addon/components/order-invoice.js
+++ b/addon/components/order-invoice.js
@@ -92,10 +92,12 @@ export default class OrderInvoiceComponent extends Component {
             const results = yield this.store.query('ledger-invoice', {
                 order_uuid: order.id,
                 with: 'items',
-                limit: 1,
+                sort: '-created_at',
+                limit: 10,
             });
 
-            this.invoice = results.firstObject ?? null;
+            const invoices = results.toArray();
+            this.invoice = invoices.find((invoice) => !['void', 'cancelled'].includes(invoice.status)) ?? invoices[0] ?? null;
         } catch {
             this.invoice = null;
         }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "fleetbase/ledger-api",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Accounting & Invoicing Extension for Fleetbase",
     "keywords": [
         "fleetbase",

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
     "name": "Ledger",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Accounting & Invoicing Extension for Fleetbase",
     "repository": "https://github.com/fleetbase/ledger",
     "license": "AGPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@fleetbase/ledger-engine",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "description": "Accounting & Invoicing Extension for Fleetbase",
     "keywords": [
         "fleetbase-extension",
@@ -46,7 +46,7 @@
         "@babel/core": "^7.23.2",
         "@fleetbase/ember-core": "^0.3.17",
         "@fleetbase/ember-ui": "^0.3.25",
-        "@fleetbase/fleetops-data": "^0.1.25",
+        "@fleetbase/fleetops-data": "^0.1.30",
         "@fortawesome/ember-fontawesome": "^2.0.0",
         "@fortawesome/fontawesome-svg-core": "6.4.0",
         "@fortawesome/free-brands-svg-icons": "6.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^0.3.25
         version: 0.3.25(@ember/test-helpers@3.2.0(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(webpack@5.89.0))(@glimmer/component@1.1.2(@babel/core@7.23.2))(@glimmer/tracking@1.1.2)(ember-resolver@11.0.1(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0)))(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(postcss@8.4.35)(rollup@2.79.1)(tracked-built-ins@3.4.0(@babel/core@7.23.2))(webpack@5.89.0)
       '@fleetbase/fleetops-data':
-        specifier: ^0.1.25
-        version: 0.1.25(@ember/string@3.1.1)(@ember/test-helpers@3.2.0(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(webpack@5.89.0))(ember-resolver@11.0.1(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0)))(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(eslint@8.52.0)(webpack@5.89.0)
+        specifier: ^0.1.30
+        version: 0.1.30(@ember/string@3.1.1)(@ember/test-helpers@3.2.0(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(webpack@5.89.0))(ember-resolver@11.0.1(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0)))(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(eslint@8.52.0)(webpack@5.89.0)
       '@fortawesome/ember-fontawesome':
         specifier: ^2.0.0
         version: 2.0.0(@babel/core@7.23.2)(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(rollup@2.79.1)(webpack@5.89.0)
@@ -1915,12 +1915,16 @@ packages:
     resolution: {integrity: sha512-fFyorS6Ir/lW2u1y/d46U/0PoIhz4JKSVJZJddveIPK3v/0shpHRRsI4gnW+EtIzE3Dgq6Z7p6pQvrPBpPw/YQ==}
     engines: {node: '>= 18'}
 
+  '@fleetbase/ember-core@0.3.18':
+    resolution: {integrity: sha512-XA/Ysn3NlM37qK/xJCY+Uo2sZ8JTwcDaGruPi8dSVyGfYHO55m96TepCChEU18GdwosbsBBfL8C2R+fUvPsqIg==}
+    engines: {node: '>= 18'}
+
   '@fleetbase/ember-ui@0.3.25':
     resolution: {integrity: sha512-CM0dXMlFe3VyIGFgmbRDEK+e/Y79Ezu4T57geJF2cHr+/1f3oLvhLqPaZIs1J1TTSgcvCl3E+owcYWw2mWxLlg==}
     engines: {node: '>= 18'}
 
-  '@fleetbase/fleetops-data@0.1.25':
-    resolution: {integrity: sha512-uCX/qB4ANDGNN+EM1vdsVc4inprGEwj1dT0G5OTYKsFaHL3CWOeXsOg8qSa5EDClqxIodadx6stB+dSwrhYowg==}
+  '@fleetbase/fleetops-data@0.1.30':
+    resolution: {integrity: sha512-n+jCGT2tFnhduHDEkBPENNn9UTaWNSygW9ZmNYiRs6fnGFaRsrMfvBrW+N9galB2dpvA7M8bJO+bl/exkb4dnA==}
     engines: {node: '>= 18'}
 
   '@floating-ui/core@1.7.5':
@@ -9359,6 +9363,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-define-polyfill-provider@0.5.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-compilation-targets': 7.23.6
+      '@babel/helper-plugin-utils': 7.22.5
+      debug: 4.3.4
+      lodash.debounce: 4.0.8
+      resolve: 1.22.8
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-define-polyfill-provider@0.6.6(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -9425,6 +9440,15 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
 
+  '@babel/helper-module-transforms@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.20
+
   '@babel/helper-module-transforms@7.28.6(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -9458,6 +9482,13 @@ snapshots:
   '@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-wrap-function': 7.22.20
+
+  '@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-wrap-function': 7.22.20
@@ -9615,6 +9646,11 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -9631,6 +9667,13 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-transform-optional-chaining': 7.23.4(@babel/core@7.23.2)
+
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/plugin-transform-optional-chaining': 7.23.4(@babel/core@7.29.0)
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.23.2)':
     dependencies:
@@ -9653,6 +9696,12 @@ snapshots:
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.23.7(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.23.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-plugin-utils': 7.22.5
 
@@ -9743,9 +9792,22 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.2)
 
+  '@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
+
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.2)':
@@ -9753,9 +9815,19 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-decorators@7.23.3(@babel/core@7.23.2)':
@@ -9783,14 +9855,29 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-import-assertions@7.23.3(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-syntax-import-assertions@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.23.2)':
@@ -9808,6 +9895,11 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-import-attributes@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -9823,9 +9915,19 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.23.2)':
@@ -9833,9 +9935,19 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.2)':
@@ -9843,9 +9955,19 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.2)':
@@ -9853,9 +9975,19 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.23.2)':
@@ -9863,14 +9995,29 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-syntax-typescript@7.23.3(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-syntax-typescript@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.23.2)':
@@ -9900,6 +10047,11 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-arrow-functions@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -9917,6 +10069,14 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.2)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.2)
+
+  '@babel/plugin-transform-async-generator-functions@7.23.9(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.29.0)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.0)
 
   '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.23.2)':
     dependencies:
@@ -9943,6 +10103,13 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.2)
 
+  '@babel/plugin-transform-async-to-generator@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.29.0)
+
   '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -9966,6 +10133,11 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-block-scoped-functions@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -9979,6 +10151,11 @@ snapshots:
   '@babel/plugin-transform-block-scoping@7.23.4(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-block-scoping@7.23.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.23.2)':
@@ -9995,6 +10172,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.2)
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-class-properties@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.23.2)':
@@ -10019,6 +10202,13 @@ snapshots:
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.2)
+
+  '@babel/plugin-transform-class-static-block@7.23.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0)
 
   '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.23.2)':
     dependencies:
@@ -10045,6 +10235,18 @@ snapshots:
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.2)
+      '@babel/helper-split-export-declaration': 7.22.6
+      globals: 11.12.0
+
+  '@babel/plugin-transform-classes@7.23.8(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-compilation-targets': 7.23.6
+      '@babel/helper-environment-visitor': 7.22.20
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.29.0)
       '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
 
@@ -10078,6 +10280,12 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/template': 7.23.9
 
+  '@babel/plugin-transform-computed-properties@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/template': 7.23.9
+
   '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10093,6 +10301,11 @@ snapshots:
   '@babel/plugin-transform-destructuring@7.23.3(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-destructuring@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.23.2)':
@@ -10117,6 +10330,12 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-dotall-regex@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10132,6 +10351,11 @@ snapshots:
   '@babel/plugin-transform-duplicate-keys@7.23.3(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-duplicate-keys@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.23.2)':
@@ -10161,6 +10385,12 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.2)
+
+  '@babel/plugin-transform-dynamic-import@7.23.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.0)
 
   '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.23.2)':
     dependencies:
@@ -10194,6 +10424,12 @@ snapshots:
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-exponentiation-operator@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10210,6 +10446,12 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.2)
 
+  '@babel/plugin-transform-export-namespace-from@7.23.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.29.0)
+
   '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10223,6 +10465,12 @@ snapshots:
   '@babel/plugin-transform-for-of@7.23.6(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+
+  '@babel/plugin-transform-for-of@7.23.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
@@ -10245,6 +10493,13 @@ snapshots:
   '@babel/plugin-transform-function-name@7.23.3(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-compilation-targets': 7.23.6
+      '@babel/helper-function-name': 7.23.0
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-function-name@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
@@ -10273,6 +10528,12 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.2)
 
+  '@babel/plugin-transform-json-strings@7.23.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0)
+
   '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10286,6 +10547,11 @@ snapshots:
   '@babel/plugin-transform-literals@7.23.3(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-literals@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-literals@7.27.1(@babel/core@7.23.2)':
@@ -10304,6 +10570,12 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.2)
 
+  '@babel/plugin-transform-logical-assignment-operators@7.23.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0)
+
   '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10317,6 +10589,11 @@ snapshots:
   '@babel/plugin-transform-member-expression-literals@7.23.3(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-member-expression-literals@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.23.2)':
@@ -10333,6 +10610,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.2)
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-modules-amd@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.23.2)':
@@ -10358,6 +10641,13 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
 
+  '@babel/plugin-transform-modules-commonjs@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+
   '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10379,6 +10669,14 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.2)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.20
+
+  '@babel/plugin-transform-modules-systemjs@7.23.9(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-identifier': 7.22.20
 
@@ -10408,6 +10706,12 @@ snapshots:
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-modules-umd@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-transforms': 7.23.3(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10430,6 +10734,12 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10445,6 +10755,11 @@ snapshots:
   '@babel/plugin-transform-new-target@7.23.3(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-new-target@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.23.2)':
@@ -10463,6 +10778,12 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.2)
 
+  '@babel/plugin-transform-nullish-coalescing-operator@7.23.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
+
   '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10478,6 +10799,12 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.2)
+
+  '@babel/plugin-transform-numeric-separator@7.23.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.0)
 
   '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.23.2)':
     dependencies:
@@ -10497,6 +10824,15 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.2)
       '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.23.2)
+
+  '@babel/plugin-transform-object-rest-spread@7.23.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/compat-data': 7.23.5
+      '@babel/core': 7.29.0
+      '@babel/helper-compilation-targets': 7.23.6
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.29.0)
 
   '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.23.2)':
     dependencies:
@@ -10526,6 +10862,12 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.2)
 
+  '@babel/plugin-transform-object-super@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-replace-supers': 7.22.20(@babel/core@7.29.0)
+
   '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10548,6 +10890,12 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.2)
 
+  '@babel/plugin-transform-optional-catch-binding@7.23.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.0)
+
   '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10564,6 +10912,13 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.2)
+
+  '@babel/plugin-transform-optional-chaining@7.23.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
 
   '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.23.2)':
     dependencies:
@@ -10586,6 +10941,11 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-parameters@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10600,6 +10960,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.2)
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-private-methods@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.23.2)':
@@ -10626,6 +10992,14 @@ snapshots:
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.23.2)
 
+  '@babel/plugin-transform-private-property-in-object@7.23.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
+
   '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10649,6 +11023,11 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-property-literals@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10662,6 +11041,12 @@ snapshots:
   '@babel/plugin-transform-regenerator@7.23.3(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+      regenerator-transform: 0.15.2
+
+  '@babel/plugin-transform-regenerator@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.2
 
@@ -10692,6 +11077,11 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-reserved-words@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10710,6 +11100,18 @@ snapshots:
       babel-plugin-polyfill-corejs2: 0.4.8(@babel/core@7.23.2)
       babel-plugin-polyfill-corejs3: 0.9.0(@babel/core@7.23.2)
       babel-plugin-polyfill-regenerator: 0.5.5(@babel/core@7.23.2)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-runtime@7.23.9(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/helper-plugin-utils': 7.22.5
+      babel-plugin-polyfill-corejs2: 0.4.8(@babel/core@7.29.0)
+      babel-plugin-polyfill-corejs3: 0.9.0(@babel/core@7.29.0)
+      babel-plugin-polyfill-regenerator: 0.5.5(@babel/core@7.29.0)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -10743,6 +11145,11 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-shorthand-properties@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10756,6 +11163,12 @@ snapshots:
   '@babel/plugin-transform-spread@7.23.3(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+
+  '@babel/plugin-transform-spread@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
@@ -10780,6 +11193,11 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-sticky-regex@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10795,6 +11213,11 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-template-literals@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10808,6 +11231,11 @@ snapshots:
   '@babel/plugin-transform-typeof-symbol@7.23.3(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-typeof-symbol@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.23.2)':
@@ -10827,6 +11255,14 @@ snapshots:
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.23.2)
+
+  '@babel/plugin-transform-typescript@7.23.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.29.0)
 
   '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.23.2)':
     dependencies:
@@ -10875,6 +11311,11 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-unicode-escapes@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10889,6 +11330,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-unicode-property-regex@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.23.2)':
@@ -10909,6 +11356,12 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
       '@babel/helper-plugin-utils': 7.22.5
 
+  '@babel/plugin-transform-unicode-regex@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.22.5
+
   '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.23.2)':
     dependencies:
       '@babel/core': 7.23.2
@@ -10925,6 +11378,12 @@ snapshots:
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.2)
+      '@babel/helper-plugin-utils': 7.22.5
+
+  '@babel/plugin-transform-unicode-sets-regex@7.23.3(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.23.2)':
@@ -11025,6 +11484,92 @@ snapshots:
       babel-plugin-polyfill-corejs2: 0.4.8(@babel/core@7.23.2)
       babel-plugin-polyfill-corejs3: 0.9.0(@babel/core@7.23.2)
       babel-plugin-polyfill-regenerator: 0.5.5(@babel/core@7.23.2)
+      core-js-compat: 3.36.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/preset-env@7.23.9(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/compat-data': 7.23.5
+      '@babel/core': 7.29.0
+      '@babel/helper-compilation-targets': 7.23.6
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.23.5
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.23.7(@babel/core@7.29.0)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.0)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-assertions': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-arrow-functions': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-async-generator-functions': 7.23.9(@babel/core@7.29.0)
+      '@babel/plugin-transform-async-to-generator': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-block-scoped-functions': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-block-scoping': 7.23.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-properties': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-static-block': 7.23.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-classes': 7.23.8(@babel/core@7.29.0)
+      '@babel/plugin-transform-computed-properties': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-destructuring': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-dotall-regex': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-duplicate-keys': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-dynamic-import': 7.23.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-exponentiation-operator': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-export-namespace-from': 7.23.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-for-of': 7.23.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-function-name': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-json-strings': 7.23.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-literals': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-logical-assignment-operators': 7.23.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-member-expression-literals': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-amd': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-systemjs': 7.23.9(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-umd': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.29.0)
+      '@babel/plugin-transform-new-target': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.23.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-numeric-separator': 7.23.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-object-rest-spread': 7.23.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-object-super': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-catch-binding': 7.23.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-chaining': 7.23.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-methods': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-private-property-in-object': 7.23.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-property-literals': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-regenerator': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-reserved-words': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-shorthand-properties': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-spread': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-sticky-regex': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-template-literals': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-typeof-symbol': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-escapes': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-property-regex': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-regex': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-sets-regex': 7.23.3(@babel/core@7.29.0)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0)
+      babel-plugin-polyfill-corejs2: 0.4.8(@babel/core@7.29.0)
+      babel-plugin-polyfill-corejs3: 0.9.0(@babel/core@7.29.0)
+      babel-plugin-polyfill-regenerator: 0.5.5(@babel/core@7.29.0)
       core-js-compat: 3.36.0
       semver: 6.3.1
     transitivePeerDependencies:
@@ -11585,7 +12130,7 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/model@4.12.5(@babel/core@7.23.2)(@ember-data/debug@4.12.5)(@ember-data/graph@4.12.5)(@ember-data/json-api@4.12.5)(@ember-data/legacy-compat@4.12.5)(@ember-data/store@4.12.5)(@ember-data/tracking@4.12.5)(@ember/string@3.1.1)(ember-inflector@4.0.2)(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))':
+  '@ember-data/model@4.12.5(@babel/core@7.23.2)(@ember-data/debug@4.12.5)(@ember-data/graph@4.12.5)(@ember-data/json-api@4.12.5)(@ember-data/legacy-compat@4.12.5)(@ember-data/store@4.12.5)(@ember-data/tracking@4.12.5)(@ember/string@3.1.1)(ember-inflector@4.0.3(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0)))(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))':
     dependencies:
       '@ember-data/legacy-compat': 4.12.5(@ember-data/graph@4.12.5)(@ember-data/json-api@4.12.5)
       '@ember-data/private-build-infra': 4.12.5
@@ -11598,7 +12143,7 @@ snapshots:
       ember-cli-babel: 7.26.11
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
-      ember-inflector: 4.0.2
+      ember-inflector: 4.0.3(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))
       inflection: 2.0.1
     optionalDependencies:
       '@ember-data/debug': 4.12.5(@ember-data/store@4.12.5)(@ember/string@3.1.1)(webpack@5.89.0)
@@ -11679,7 +12224,7 @@ snapshots:
       '@ember-data/graph': 4.12.5(@ember-data/store@4.12.5)
       '@ember-data/json-api': 4.12.5(@ember-data/graph@4.12.5)(@ember-data/store@4.12.5)
       '@ember-data/legacy-compat': 4.12.5(@ember-data/graph@4.12.5)(@ember-data/json-api@4.12.5)
-      '@ember-data/model': 4.12.5(@babel/core@7.23.2)(@ember-data/debug@4.12.5)(@ember-data/graph@4.12.5)(@ember-data/json-api@4.12.5)(@ember-data/legacy-compat@4.12.5)(@ember-data/store@4.12.5)(@ember-data/tracking@4.12.5)(@ember/string@3.1.1)(ember-inflector@4.0.2)(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))
+      '@ember-data/model': 4.12.5(@babel/core@7.23.2)(@ember-data/debug@4.12.5)(@ember-data/graph@4.12.5)(@ember-data/json-api@4.12.5)(@ember-data/legacy-compat@4.12.5)(@ember-data/store@4.12.5)(@ember-data/tracking@4.12.5)(@ember/string@3.1.1)(ember-inflector@4.0.3(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0)))(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -11947,13 +12492,46 @@ snapshots:
   '@fleetbase/ember-accounting@0.0.1(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))':
     dependencies:
       '@babel/core': 7.23.2
-      ember-cli-babel: 8.3.1(@babel/core@7.23.2)
+      ember-cli-babel: 8.2.0(@babel/core@7.23.2)
       ember-cli-htmlbars: 6.3.0
       ember-source: 5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0)
     transitivePeerDependencies:
       - supports-color
 
   '@fleetbase/ember-core@0.3.17(@ember/string@3.1.1)(@ember/test-helpers@3.2.0(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(webpack@5.89.0))(ember-resolver@11.0.1(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0)))(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(eslint@8.52.0)(webpack@5.89.0)':
+    dependencies:
+      '@babel/core': 7.23.2
+      compress-json: 3.4.0
+      date-fns: 2.30.0
+      ember-auto-import: 2.8.1(webpack@5.89.0)
+      ember-can: 6.0.0(@babel/core@7.23.2)(@ember/string@3.1.1)(ember-inflector@4.0.3(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0)))(ember-resolver@11.0.1(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0)))(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))
+      ember-cli-babel: 8.2.0(@babel/core@7.23.2)
+      ember-cli-htmlbars: 6.3.0
+      ember-cli-notifications: 9.1.0(@babel/core@7.23.2)(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))
+      ember-concurrency: 4.0.6(@babel/core@7.23.2)
+      ember-decorators: 6.1.1
+      ember-get-config: 2.1.1(@babel/core@7.23.2)
+      ember-inflector: 4.0.3(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))
+      ember-intl: 6.3.2(@babel/core@7.23.2)(webpack@5.89.0)
+      ember-loading: 2.0.0(@babel/core@7.23.2)
+      ember-local-storage: 2.0.7(@babel/core@7.23.2)
+      ember-simple-auth: 6.1.0(@babel/core@7.23.2)(@ember/test-helpers@3.2.0(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(webpack@5.89.0))(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(eslint@8.52.0)
+      ember-wormhole: 0.6.0
+      socketcluster-client: 17.2.2
+    transitivePeerDependencies:
+      - '@ember/string'
+      - '@ember/test-helpers'
+      - '@glint/template'
+      - bufferutil
+      - ember-resolver
+      - ember-source
+      - eslint
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - webpack
+
+  '@fleetbase/ember-core@0.3.18(@ember/string@3.1.1)(@ember/test-helpers@3.2.0(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(webpack@5.89.0))(ember-resolver@11.0.1(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0)))(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(eslint@8.52.0)(webpack@5.89.0)':
     dependencies:
       '@babel/core': 7.23.2
       compress-json: 3.4.0
@@ -12090,10 +12668,10 @@ snapshots:
       - webpack-command
       - yaml
 
-  '@fleetbase/fleetops-data@0.1.25(@ember/string@3.1.1)(@ember/test-helpers@3.2.0(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(webpack@5.89.0))(ember-resolver@11.0.1(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0)))(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(eslint@8.52.0)(webpack@5.89.0)':
+  '@fleetbase/fleetops-data@0.1.30(@ember/string@3.1.1)(@ember/test-helpers@3.2.0(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(webpack@5.89.0))(ember-resolver@11.0.1(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0)))(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(eslint@8.52.0)(webpack@5.89.0)':
     dependencies:
       '@babel/core': 7.23.2
-      '@fleetbase/ember-core': 0.3.17(@ember/string@3.1.1)(@ember/test-helpers@3.2.0(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(webpack@5.89.0))(ember-resolver@11.0.1(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0)))(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(eslint@8.52.0)(webpack@5.89.0)
+      '@fleetbase/ember-core': 0.3.18(@ember/string@3.1.1)(@ember/test-helpers@3.2.0(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(webpack@5.89.0))(ember-resolver@11.0.1(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0)))(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))(eslint@8.52.0)(webpack@5.89.0)
       date-fns: 2.30.0
       ember-cli-babel: 8.2.0(@babel/core@7.23.2)
       ember-cli-htmlbars: 6.3.0
@@ -13395,15 +13973,6 @@ snapshots:
       schema-utils: 2.7.1
       webpack: 5.89.0
 
-  babel-loader@8.3.0(@babel/core@7.29.0)(webpack@5.89.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      find-cache-dir: 3.3.2
-      loader-utils: 2.0.4
-      make-dir: 3.1.0
-      schema-utils: 2.7.1
-      webpack: 5.89.0
-
   babel-messages@6.23.0:
     dependencies:
       babel-runtime: 6.26.0
@@ -13504,6 +14073,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-polyfill-corejs2@0.4.8(@babel/core@7.29.0):
+    dependencies:
+      '@babel/compat-data': 7.23.5
+      '@babel/core': 7.29.0
+      '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.29.0)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.23.2):
     dependencies:
       '@babel/core': 7.23.2
@@ -13544,10 +14122,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-polyfill-corejs3@0.9.0(@babel/core@7.29.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.29.0)
+      core-js-compat: 3.36.0
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-polyfill-regenerator@0.5.5(@babel/core@7.23.2):
     dependencies:
       '@babel/core': 7.23.2
       '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.23.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-regenerator@0.5.5(@babel/core@7.29.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13786,6 +14379,20 @@ snapshots:
   broccoli-babel-transpiler@8.0.0(@babel/core@7.23.2):
     dependencies:
       '@babel/core': 7.23.2
+      broccoli-persistent-filter: 3.1.3
+      clone: 2.1.2
+      hash-for-dep: 1.5.1
+      heimdalljs: 0.2.6
+      heimdalljs-logger: 0.1.10
+      json-stable-stringify: 1.1.1
+      rsvp: 4.8.5
+      workerpool: 6.5.1
+    transitivePeerDependencies:
+      - supports-color
+
+  broccoli-babel-transpiler@8.0.0(@babel/core@7.29.0):
+    dependencies:
+      '@babel/core': 7.29.0
       broccoli-persistent-filter: 3.1.3
       clone: 2.1.2
       hash-for-dep: 1.5.1
@@ -15236,16 +15843,16 @@ snapshots:
 
   ember-auto-import@2.12.1(webpack@5.89.0):
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.0)
-      '@babel/plugin-proposal-decorators': 7.23.2(@babel/core@7.29.0)
-      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
-      '@babel/preset-env': 7.29.0(@babel/core@7.29.0)
-      '@embroider/macros': 1.20.0(@babel/core@7.29.0)
+      '@babel/core': 7.23.2
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.23.2)
+      '@babel/plugin-proposal-decorators': 7.23.2(@babel/core@7.23.2)
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.23.2)
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.23.2)
+      '@babel/preset-env': 7.29.0(@babel/core@7.23.2)
+      '@embroider/macros': 1.20.0(@babel/core@7.23.2)
       '@embroider/reverse-exports': 0.2.0
       '@embroider/shared-internals': 2.5.2
-      babel-loader: 8.3.0(@babel/core@7.29.0)(webpack@5.89.0)
+      babel-loader: 8.3.0(@babel/core@7.23.2)(webpack@5.89.0)
       babel-plugin-ember-modules-api-polyfill: 3.5.0
       babel-plugin-ember-template-compilation: 2.2.1
       babel-plugin-htmlbars-inline-precompile: 5.3.1
@@ -15436,6 +16043,39 @@ snapshots:
       babel-plugin-ember-modules-api-polyfill: 3.5.0
       babel-plugin-module-resolver: 5.0.0
       broccoli-babel-transpiler: 8.0.0(@babel/core@7.23.2)
+      broccoli-debug: 0.6.5
+      broccoli-funnel: 3.0.8
+      broccoli-source: 3.0.1
+      calculate-cache-key-for-tree: 2.0.0
+      clone: 2.1.2
+      ember-cli-babel-plugin-helpers: 1.1.1
+      ember-cli-version-checker: 5.1.2
+      ensure-posix-path: 1.1.1
+      resolve-package-path: 4.0.3
+      semver: 7.6.0
+    transitivePeerDependencies:
+      - supports-color
+
+  ember-cli-babel@8.2.0(@babel/core@7.29.0):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-compilation-targets': 7.23.6
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.0)
+      '@babel/plugin-proposal-decorators': 7.23.2(@babel/core@7.29.0)
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.29.0)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.11(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-static-block': 7.23.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-modules-amd': 7.23.3(@babel/core@7.29.0)
+      '@babel/plugin-transform-runtime': 7.23.9(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.23.6(@babel/core@7.29.0)
+      '@babel/preset-env': 7.23.9(@babel/core@7.29.0)
+      '@babel/runtime': 7.12.18
+      amd-name-resolver: 1.3.1
+      babel-plugin-debug-macros: 0.3.4(@babel/core@7.29.0)
+      babel-plugin-ember-data-packages-polyfill: 0.1.2
+      babel-plugin-ember-modules-api-polyfill: 3.5.0
+      babel-plugin-module-resolver: 5.0.0
+      broccoli-babel-transpiler: 8.0.0(@babel/core@7.29.0)
       broccoli-debug: 0.6.5
       broccoli-funnel: 3.0.8
       broccoli-source: 3.0.1
@@ -16075,7 +16715,7 @@ snapshots:
       '@ember-data/graph': 4.12.5(@ember-data/store@4.12.5)
       '@ember-data/json-api': 4.12.5(@ember-data/graph@4.12.5)(@ember-data/store@4.12.5)
       '@ember-data/legacy-compat': 4.12.5(@ember-data/graph@4.12.5)(@ember-data/json-api@4.12.5)
-      '@ember-data/model': 4.12.5(@babel/core@7.23.2)(@ember-data/debug@4.12.5)(@ember-data/graph@4.12.5)(@ember-data/json-api@4.12.5)(@ember-data/legacy-compat@4.12.5)(@ember-data/store@4.12.5)(@ember-data/tracking@4.12.5)(@ember/string@3.1.1)(ember-inflector@4.0.2)(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))
+      '@ember-data/model': 4.12.5(@babel/core@7.23.2)(@ember-data/debug@4.12.5)(@ember-data/graph@4.12.5)(@ember-data/json-api@4.12.5)(@ember-data/legacy-compat@4.12.5)(@ember-data/store@4.12.5)(@ember-data/tracking@4.12.5)(@ember/string@3.1.1)(ember-inflector@4.0.3(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0)))(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0))
       '@ember-data/private-build-infra': 4.12.5
       '@ember-data/request': 4.12.5
       '@ember-data/serializer': 4.12.5(@ember-data/store@4.12.5(@babel/core@7.23.2)(@ember-data/graph@4.12.5)(@ember-data/json-api@4.12.5)(@ember-data/legacy-compat@4.12.5)(@ember-data/model@4.12.5)(@ember-data/tracking@4.12.5)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(ember-source@5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0)))(@ember/string@3.1.1)(ember-inflector@4.0.2)
@@ -16118,7 +16758,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       ember-auto-import: 2.12.1(webpack@5.89.0)
-      ember-cli-babel: 8.3.1(@babel/core@7.29.0)
+      ember-cli-babel: 8.2.0(@babel/core@7.29.0)
       ember-cli-htmlbars: 6.3.0
       ember-element-helper: 0.8.8
       ember-source: 5.4.0(@babel/core@7.23.2)(@glimmer/component@1.1.2(@babel/core@7.23.2))(rsvp@4.8.5)(webpack@5.89.0)

--- a/server/src/Observers/PurchaseRateObserver.php
+++ b/server/src/Observers/PurchaseRateObserver.php
@@ -3,6 +3,7 @@
 namespace Fleetbase\Ledger\Observers;
 
 use Fleetbase\Ledger\Services\InvoiceService;
+use Fleetbase\Ledger\Models\Invoice;
 use Illuminate\Support\Facades\Log;
 
 /**
@@ -56,10 +57,7 @@ class PurchaseRateObserver
                 return;
             }
 
-            // Skip if an invoice already exists for this order (idempotency).
-            if ($this->invoiceAlreadyExists($order->uuid)) {
-                return;
-            }
+            $this->supersedeDraftInvoices($order->uuid);
 
             // Resolve currency: prefer the service quote's currency, fall back to
             // the company's country-derived currency, then USD.
@@ -124,10 +122,14 @@ class PurchaseRateObserver
     }
 
     /**
-     * Check whether a Ledger invoice already exists for the given order UUID.
+     * Void prior draft invoices so the newly created invoice becomes the active revision.
      */
-    private function invoiceAlreadyExists(string $orderUuid): bool
+    private function supersedeDraftInvoices(string $orderUuid): void
     {
-        return \Fleetbase\Ledger\Models\Invoice::where('order_uuid', $orderUuid)->exists();
+        Invoice::where('order_uuid', $orderUuid)
+            ->where('status', 'draft')
+            ->update([
+                'status' => 'void',
+            ]);
     }
 }


### PR DESCRIPTION
## Summary
- make Ledger revision-aware when orders are repriced through a new purchase rate
- always create a new invoice for the new pricing revision instead of skipping invoice generation when one already exists
- update the FleetOps invoice tab to prefer the newest active invoice revision for an order

## What Changed
- replaced the previous one-invoice-per-order guard in the purchase-rate observer
- voided prior draft invoices before creating the next invoice revision
- preserved sent and paid invoices as historical accounting records
- kept invoice creation sourced from the purchase rate event flow
- updated the order invoice component to fetch recent invoices and select the newest non-void, non-cancelled revision first

## Verification
- `php -l server/src/Observers/PurchaseRateObserver.php`

## Notes
- this PR is intentionally focused on Ledger revision behavior only
- style-only lint/prettier cleanup was intentionally left out of scope for this PR
